### PR TITLE
Update ex.cpp

### DIFF
--- a/utils/ex.cpp
+++ b/utils/ex.cpp
@@ -1,3 +1,4 @@
+// cppimport
 #include<iostream>
 #include<pybind11/pybind11.h>
 #include<pybind11/numpy.h>


### PR DESCRIPTION
According to the official description of [cppimport](https://github.com/tbenthompson/cppimport), this line is essential: "the comment at top is essential to opt in to cppimport. Don't forget this! "

If you do not add it, it will raise this error:

"ModuleNotFoundError: No module named 'utils.ex'"